### PR TITLE
Cipher Service

### DIFF
--- a/app/.vscode/settings.json
+++ b/app/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": true
+}

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@nestjs/common": "^10.0.0",
         "@nestjs/core": "^10.0.0",
+        "@nestjs/mapped-types": "^2.0.2",
         "@nestjs/platform-express": "^10.0.0",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1"
@@ -1581,6 +1582,25 @@
           "optional": true
         },
         "@nestjs/websockets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.2.tgz",
+      "integrity": "sha512-V0izw6tWs6fTp9+KiiPUbGHWALy563Frn8X6Bm87ANLRuE46iuBMD5acKBDP5lKL/75QFvrzSJT7HkCbB0jTpg==",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
           "optional": true
         }
       }

--- a/app/package.json
+++ b/app/package.json
@@ -59,7 +59,7 @@
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
+      "^.+\\.(t|j)s$": ["ts-jest", { "isolatedModules": true }]
     },
     "collectCoverageFrom": [
       "**/*.(t|j)s"

--- a/app/package.json
+++ b/app/package.json
@@ -10,18 +10,19 @@
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",
-    "start:debug": "nest start --debug --watch",
+    "start:debug": "nest start --debug --watch --inspect",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test:debug": "node --inspect -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand --testTimeout 5000000",
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
+    "@nestjs/mapped-types": "^2.0.2",
     "@nestjs/platform-express": "^10.0.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1"

--- a/app/src/app.envvars.ts
+++ b/app/src/app.envvars.ts
@@ -1,0 +1,19 @@
+import { MissingEnvironmentVariables } from './exceptions';
+
+export enum AppVars {
+  TURNSTILE_SECRET = 'TURNSTILE_SECRET',
+}
+
+export function checkNeededEnvironmentVariables(): void {
+  let missingEnvVars: string[] = [];
+  for (let envVar in AppVars) {
+    console.log(process.env[envVar]);
+    if (!process.env[envVar]) {
+      console.log('pushing');
+      missingEnvVars.push(envVar);
+    }
+  }
+  if (missingEnvVars.length > 0) {
+    throw new MissingEnvironmentVariables(missingEnvVars);
+  }
+}

--- a/app/src/app.module.ts
+++ b/app/src/app.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { CipherModule } from './modules/cipher.module';
+import { TokensModule } from './tokens/tokens.module';
 
 @Module({
-  imports: [],
+  imports: [CipherModule, TokensModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/app/src/app.module.ts
+++ b/app/src/app.module.ts
@@ -3,10 +3,11 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { CipherModule } from './modules/cipher.module';
 import { TokensModule } from './tokens/tokens.module';
+import { CipherService } from './cipher/cipher.service';
 
 @Module({
   imports: [CipherModule, TokensModule],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, CipherService],
 })
 export class AppModule {}

--- a/app/src/app.variables.spec.ts
+++ b/app/src/app.variables.spec.ts
@@ -1,0 +1,38 @@
+import { AppVars, checkNeededEnvironmentVariables } from './app.envvars';
+import { MissingEnvironmentVariables } from './exceptions';
+
+describe('App Environment variables', () => {
+  let oldVars: Map<string, string> = new Map();
+
+  const test_secret = 'This_is_a_secret';
+
+  beforeEach(() => {
+    for (let envVar in AppVars) {
+      oldVars[envVar] = process.env[envVar];
+    }
+  });
+
+  afterEach(() => {
+    for (let envVar in AppVars) {
+      if (oldVars[envVar] === undefined) {
+        //See node docs on process.env object --
+        //implicit string casting when setting properties is deprecated.
+        //So, I instead manually delete the property.
+        delete process.env[envVar];
+      } else {
+        process.env[envVar] = oldVars[envVar];
+      }
+    }
+  });
+
+  it('Checks that all needed environment variables are present', () => {
+    process.env[AppVars.TURNSTILE_SECRET] = test_secret;
+    checkNeededEnvironmentVariables();
+  });
+
+  it('Throws informatively if an environment variable is missing', () => {
+    expect(checkNeededEnvironmentVariables).toThrow(
+      new MissingEnvironmentVariables([AppVars.TURNSTILE_SECRET]),
+    );
+  });
+});

--- a/app/src/cipher/cipher.service.spec.ts
+++ b/app/src/cipher/cipher.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CipherService } from './cipher.service';
+
+describe('CipherService', () => {
+  let service: CipherService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CipherService],
+    }).compile();
+
+    service = module.get<CipherService>(CipherService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/app/src/cipher/cipher.service.spec.ts
+++ b/app/src/cipher/cipher.service.spec.ts
@@ -1,18 +1,25 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CipherService } from './cipher.service';
+import { AppVars } from '../app.envvars';
+import { MockCipherService } from '../../test/mocks/cipher.service.mock';
+import { Cipher } from 'crypto';
 
 describe('CipherService', () => {
   let testService: CipherService;
+  let mockService: CipherService;
 
   const testUUID: string = '2fda8229-a4d7-43da-99cf-2644a28417aa';
-  const testEncryptedValue: string = 'TheDummyIV:TheEncryptedValueToBeFilledIn';
+  const testEncryptedValue: string =
+    '30313233343536373839616263646566_729d05ed41aac767b113ef260a95e4e040575bb4263999d266eee5168308f2223ed002bb83f7d99af9f2ed7c62dca334';
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [CipherService],
+      providers: [CipherService, MockCipherService],
     }).compile();
 
     testService = module.get<CipherService>(CipherService);
+    mockService = module.get<MockCipherService>(MockCipherService);
+    process.env[AppVars.TURNSTILE_SECRET] = 'this is a test secret';
   });
 
   it('should be defined', () => {
@@ -20,13 +27,16 @@ describe('CipherService', () => {
   });
 
   it('Encrypts a uuid into an encrypted value', async () => {
-    expect(await testService.encrypt(testUUID)).toEqual(testEncryptedValue);
+    expect(await mockService.encrypt(testUUID)).toEqual(testEncryptedValue);
   });
 
   it('Decrypts an encrypted value into a uuid', async () => {
-    expect(await testService.decrypt(testUUID)).toEqual(testEncryptedValue);
+    expect(await mockService.decrypt(testEncryptedValue)).toEqual(testUUID);
   });
 
-  it('Generates an IV of 32 bits length', () => {});
-
+  it('Returns a 16 element IV', async () => {
+    const iv: Buffer = await testService.generateIV();
+    expect(iv).toBeInstanceOf(Buffer);
+    expect(iv).toHaveLength(16);
+  });
 });

--- a/app/src/cipher/cipher.service.spec.ts
+++ b/app/src/cipher/cipher.service.spec.ts
@@ -2,17 +2,31 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { CipherService } from './cipher.service';
 
 describe('CipherService', () => {
-  let service: CipherService;
+  let testService: CipherService;
+
+  const testUUID: string = '2fda8229-a4d7-43da-99cf-2644a28417aa';
+  const testEncryptedValue: string = 'TheDummyIV:TheEncryptedValueToBeFilledIn';
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [CipherService],
     }).compile();
 
-    service = module.get<CipherService>(CipherService);
+    testService = module.get<CipherService>(CipherService);
   });
 
   it('should be defined', () => {
-    expect(service).toBeDefined();
+    expect(testService).toBeDefined();
   });
+
+  it('Encrypts a uuid into an encrypted value', async () => {
+    expect(await testService.encrypt(testUUID)).toEqual(testEncryptedValue);
+  });
+
+  it('Decrypts an encrypted value into a uuid', async () => {
+    expect(await testService.decrypt(testUUID)).toEqual(testEncryptedValue);
+  });
+
+  it('Generates an IV of 32 bits length', () => {});
+
 });

--- a/app/src/cipher/cipher.service.ts
+++ b/app/src/cipher/cipher.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CipherService {}

--- a/app/src/cipher/cipher.service.ts
+++ b/app/src/cipher/cipher.service.ts
@@ -1,4 +1,14 @@
 import { Injectable } from '@nestjs/common';
 
 @Injectable()
-export class CipherService {}
+export class CipherService {
+
+    private generateIV() {};
+
+    public async encrypt(input: string) {
+    }
+
+    public async decrypt(input: string) {
+
+    }
+}

--- a/app/src/cipher/cipher.service.ts
+++ b/app/src/cipher/cipher.service.ts
@@ -1,14 +1,56 @@
 import { Injectable } from '@nestjs/common';
+import {
+  Cipher,
+  Decipher,
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+  scryptSync,
+} from 'crypto';
+import { AppVars } from '../app.envvars';
+
+export interface IEncryptedData {
+  data: string;
+}
 
 @Injectable()
 export class CipherService {
+  private algo: string = 'aes-192-cbc';
+  private _key: Buffer;
 
-    private generateIV() {};
+  get key() {
+    if (!this._key)
+      this._key = scryptSync(
+        Buffer.from(process.env[AppVars.TURNSTILE_SECRET]), // TODO: perhaps have this loaded in by the constructor?
+        this.generateSalt(),
+        24,
+      );
+    return this._key;
+  }
 
-    public async encrypt(input: string) {
-    }
+  public generateIV(): Buffer {
+    return randomBytes(16);
+  }
 
-    public async decrypt(input: string) {
+  public generateSalt(): Buffer {
+    return Buffer.from('ConstSaltForNow');
+  }
 
-    }
+  public async encrypt(input: string): Promise<string> {
+    const iv: Buffer = this.generateIV();
+    const cipher: Cipher = createCipheriv(this.algo, this.key, iv);
+    let encrypted: string = cipher.update(input, 'utf8', 'hex');
+    encrypted += cipher.final('hex');
+    return `${iv.toString('hex')}_${encrypted}`;
+  }
+
+  public async decrypt(input: string): Promise<string> {
+    const data_split: string[] = input.split('_');
+    const iv: Buffer = Buffer.from(data_split[0], 'hex');
+    const data: string = data_split[1];
+    const decipher: Decipher = createDecipheriv(this.algo, this.key, iv);
+    let decrypted: string = decipher.update(data, 'hex', 'utf8');
+    decrypted += decipher.final('utf8');
+    return decrypted;
+  }
 }

--- a/app/src/exceptions.ts
+++ b/app/src/exceptions.ts
@@ -1,0 +1,9 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class MissingEnvironmentVariables extends Error {
+  constructor(missing_variables: string[]) {
+    super(
+      `Error! Not all environment variables required for the app are present! Missing Variables: ${missing_variables}`,
+    );
+  }
+}

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -1,7 +1,9 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { checkNeededEnvironmentVariables } from './app.envvars';
 
 async function bootstrap() {
+  checkNeededEnvironmentVariables();
   const app = await NestFactory.create(AppModule);
   await app.listen(3000);
 }

--- a/app/src/modules/cipher.module.ts
+++ b/app/src/modules/cipher.module.ts
@@ -1,0 +1,4 @@
+import { Module } from '@nestjs/common';
+
+@Module({})
+export class CipherModule {}

--- a/app/src/tokens/dto/create-token.dto.ts
+++ b/app/src/tokens/dto/create-token.dto.ts
@@ -1,0 +1,1 @@
+export class CreateTokenDto {}

--- a/app/src/tokens/dto/update-token.dto.ts
+++ b/app/src/tokens/dto/update-token.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateTokenDto } from './create-token.dto';
+
+export class UpdateTokenDto extends PartialType(CreateTokenDto) {}

--- a/app/src/tokens/entities/token.entity.ts
+++ b/app/src/tokens/entities/token.entity.ts
@@ -1,0 +1,1 @@
+export class Token {}

--- a/app/src/tokens/tokens.controller.spec.ts
+++ b/app/src/tokens/tokens.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TokensController } from './tokens.controller';
+import { TokensService } from './tokens.service';
+
+describe('TokensController', () => {
+  let controller: TokensController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TokensController],
+      providers: [TokensService],
+    }).compile();
+
+    controller = module.get<TokensController>(TokensController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/app/src/tokens/tokens.controller.ts
+++ b/app/src/tokens/tokens.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { TokensService } from './tokens.service';
+import { CreateTokenDto } from './dto/create-token.dto';
+import { UpdateTokenDto } from './dto/update-token.dto';
+
+@Controller('tokens')
+export class TokensController {
+  constructor(private readonly tokensService: TokensService) {}
+
+  @Post()
+  create(@Body() createTokenDto: CreateTokenDto) {
+    return this.tokensService.create(createTokenDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.tokensService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.tokensService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateTokenDto: UpdateTokenDto) {
+    return this.tokensService.update(+id, updateTokenDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.tokensService.remove(+id);
+  }
+}

--- a/app/src/tokens/tokens.module.ts
+++ b/app/src/tokens/tokens.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TokensService } from './tokens.service';
+import { TokensController } from './tokens.controller';
+
+@Module({
+  controllers: [TokensController],
+  providers: [TokensService],
+})
+export class TokensModule {}

--- a/app/src/tokens/tokens.service.spec.ts
+++ b/app/src/tokens/tokens.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TokensService } from './tokens.service';
+
+describe('TokensService', () => {
+  let service: TokensService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TokensService],
+    }).compile();
+
+    service = module.get<TokensService>(TokensService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/app/src/tokens/tokens.service.ts
+++ b/app/src/tokens/tokens.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateTokenDto } from './dto/create-token.dto';
+import { UpdateTokenDto } from './dto/update-token.dto';
+
+@Injectable()
+export class TokensService {
+  create(createTokenDto: CreateTokenDto) {
+    return 'This action adds a new token';
+  }
+
+  findAll() {
+    return `This action returns all tokens`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} token`;
+  }
+
+  update(id: number, updateTokenDto: UpdateTokenDto) {
+    return `This action updates a #${id} token`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} token`;
+  }
+}

--- a/app/test/mocks/cipher.service.mock.ts
+++ b/app/test/mocks/cipher.service.mock.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { CipherService } from '../../src/cipher/cipher.service';
+
+@Injectable()
+export class MockCipherService extends CipherService {
+  public generateIV(): Buffer {
+    return Buffer.from('0123456789abcdef');
+  }
+
+  public generateSalt(): Buffer {
+    return Buffer.from('ThisIsASalt');
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a class that encrypts and decrypts a string using the aes-192-cbc algorithm. This is nothing complicated, but something we'll use for token handling.

There is also some housekeeping stuff in this PR which I itemize in the changelist.

## Changelist

- Created a `CipherService` which is injectable in the nestjs framework that encrypts / decrypts a string.
- Set `isolatedModules` for the jest options. This drastically speeds up jest runtime. I will continue to hone this; my demand for tests is that they run instantly. One second is ok for now.
- Created a method that checks the needed app environment variables are set in the file `app/src/app.envvars.ts`
- Added the token CR-D scaffolding, entity, and controller using the nestjs CLI. This will be fleshed out a bit in subsequent PRs, as I still need to put in the database stuff.

## How Has This Been Tested

- New tests written for the Cipher using a `MockCipherService` which overrides the nondeterministic methods. I could use jest.fn, but decided to do this for now.
- New tests for the app environment variable checking
